### PR TITLE
style(socials): use fluent button for socials styling

### DIFF
--- a/src/components/shared/socials.tsx
+++ b/src/components/shared/socials.tsx
@@ -1,4 +1,4 @@
-import { Button, Image, Link, makeStyles, shorthands, tokens } from "@fluentui/react-components";
+import { Button, Image, makeStyles, shorthands, tokens } from "@fluentui/react-components";
 import { useDarkMode } from "../providers/darkMode";
 
 interface ISocial {

--- a/src/components/shared/socials.tsx
+++ b/src/components/shared/socials.tsx
@@ -1,4 +1,4 @@
-import { Image, Link, makeStyles, shorthands, tokens } from "@fluentui/react-components";
+import { Button, Image, Link, makeStyles, shorthands, tokens } from "@fluentui/react-components";
 import { useDarkMode } from "../providers/darkMode";
 
 interface ISocial {
@@ -13,38 +13,7 @@ const useStyles = makeStyles({
         flexWrap: 'wrap',
         justifyContent: 'center',
         alignItems: 'center',
-        ...shorthands.gap(tokens.spacingVerticalL),
-    },
-    button: {
-        display: 'grid',
-        width: '40px',
-        height: '40px',
-        backgroundColor: tokens.colorTransparentBackground,
-        alignItems: 'center',
-        justifyContent: 'center',
-        textDecorationLine: 'none',
-        ...shorthands.border('none'),
-        ...shorthands.borderRadius(tokens.borderRadiusCircular),
-        ...shorthands.outline(tokens.strokeWidthThick, 'solid', tokens.colorNeutralForeground1),
-        ...shorthands.transition('all', tokens.durationFaster),
-        ':hover': {
-            outlineOffset: tokens.strokeWidthThicker,
-            ...shorthands.transition('all', tokens.durationFaster),
-        },
-        ':focus': {
-            outlineOffset: tokens.strokeWidthThicker,
-            ...shorthands.transition('all', tokens.durationFaster),
-        },
-        '& img': {
-            ...shorthands.transition('all', tokens.durationFaster),
-        },
-        ':hover img': {
-            transform: 'scale(1.15)',
-            ...shorthands.transition('all', tokens.durationFaster),
-        },
-        ':focus img': {
-            transform: 'scale(1.5)',
-        },
+        ...shorthands.gap(tokens.spacingVerticalSNudge),
     },
 });
 
@@ -73,9 +42,17 @@ const Socials = () => {
 
     const renderButtons = (): JSX.Element[] => {
         return socialDetails.map((social, index) =>
-            <Link href={social.href} target="_blank" rel="noreferrer noopener" className={styles.button} key={index}>
-                {social.image}
-            </Link>
+            <Button
+                icon={social.image}
+                as="a"
+                appearance="subtle"
+                shape="circular"
+                size="large"
+                href={social.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                key={index}
+            />
         );
     }
 


### PR DESCRIPTION
**Summary of Changes**
Remove custom styled social button for fluent button styling.

**References and Relevant Issues**

- Closes #xxx

**Task Checklist**

- [x] Built and ran locally
- [ ] Attached an issue
- [ ] Tests added and/or updated
